### PR TITLE
Fix month parsing bug in date utility

### DIFF
--- a/src/utils/date_manupulation/get_current_month.ts
+++ b/src/utils/date_manupulation/get_current_month.ts
@@ -5,7 +5,7 @@ import { Month } from './month'
 export const getCurrentMonth = () => {
   const { data: month, success } = z
     .enum(Month)
-    .safeParse(new Date().getMonth())
+    .safeParse(new Date().getMonth() + 1)
 
   if (!success) {
     throw new Error('Invalid month')


### PR DESCRIPTION
## Summary
- align getCurrentMonth with 1-based Month enum

## Testing
- `pnpm lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689560c46b188325bca30ab6670f622b